### PR TITLE
fix(requirements.txt): move from pyreadline to pyreadline3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-pyreadline
+pyreadline3


### PR DESCRIPTION
Module `pyreadline3`, a fork of `pyreadline` no longer actively maintained on PyPI replaces its predecessor.  This equally aims to account for an reported problem using the utility in Windows.[1]

[1] https://github.com/novoid/appendfilename/issues/18